### PR TITLE
Add search by time, delete and socket support

### DIFF
--- a/main.go
+++ b/main.go
@@ -183,9 +183,9 @@ func checkTimeCondition(timestamp time.Time, condition TimeCondition) bool {
 }
 
 // checkFileTimeConditions retrieves file times and checks them against the given conditions
-func (e *Explorer) checkFileTimeConditions(fullpath string, ino uint64) (Result, bool, error) {
+func (e *Explorer) checkFileTimeConditions(fullpath string) (Result, bool, error) {
 	// Retrieve atime, ctime, and mtime of the file
-	atime, ctime, mtime, err := GetFileTimes(fullpath)
+	atime, mtime, ctime, err := GetFileTimes(fullpath)
 	if err != nil {
 		// Handle error appropriately
 		log.Println(err)
@@ -212,7 +212,6 @@ func (e *Explorer) checkFileTimeConditions(fullpath string, ino uint64) (Result,
 	// All conditions passed
 	return Result{
 		name:  fullpath,
-		ino:   ino,
 		atime: atime,
 		mtime: mtime,
 		ctime: ctime,
@@ -560,14 +559,15 @@ func (e *Explorer) readdir(dir string) {
 			switch dirent.Type {
 			case syscall.DT_DIR:
 				if e.includeDirs || e.includeAny {
-					if e.atimeOlderThan != 0 || e.atimeNewerThan != 0 {
+					if e.atimeOlderThan != 0 || e.atimeNewerThan != 0 || e.ctimeOlderThan != 0 || e.ctimeNewerThan != 0 || e.mtimeOlderThan != 0 || e.mtimeNewerThan != 0 {
 						// Call the helper function to check file times and get the Result struct
-						result, ok, err := e.checkFileTimeConditions(fullpath, GetIno(dirent))
+						result, ok, err := e.checkFileTimeConditions(fullpath)
 						if err != nil || !ok {
 							continue
 						}
 						results = append(results, result)
 					} else {
+						fmt.Println("test_dir")
 						results = append(results, Result{fullpath + string(filepath.Separator), GetIno(dirent), time.Time{}, time.Time{}, time.Time{}})
 					}
 				}

--- a/main.go
+++ b/main.go
@@ -304,7 +304,7 @@ func (e *Explorer) dumpResults() {
 					log.Println(err)
 					outputBuffer.WriteString("0")
 				} else {
-					outputBuffer.WriteString(fmt.Sprintf(" ", fileStat.Size()))
+					outputBuffer.WriteString(fmt.Sprintf(" %d", fileStat.Size()))
 				}
 			}
 			// Show atime, mtime, ctime

--- a/main.go
+++ b/main.go
@@ -251,14 +251,14 @@ func GetFileTimes(path string) (atime, mtime, ctime time.Time, err error) {
 		return time.Time{}, time.Time{}, time.Time{}, err
 	}
 
-	// Extract modification time (mtime) using fs.FileInfo
-	mtime = fileInfo.ModTime()
-
 	// Get the underlying data from the os.FileInfo object for atime and ctime
 	stat := fileInfo.Sys().(*syscall.Stat_t)
 
 	// Extract access time (atime)
 	atime = time.Unix(stat.Atim.Sec, stat.Atim.Nsec)
+
+	// Extract modification time (mtime)
+	mtime = time.Unix(stat.Mtim.Sec, stat.Mtim.Nsec)
 
 	// Extract change time (ctime)
 	ctime = time.Unix(stat.Ctim.Sec, stat.Ctim.Nsec)

--- a/main.go
+++ b/main.go
@@ -662,12 +662,12 @@ type Options struct {
 	Threads        int           `short:"j" long:"jobs" description:"Number of jobs(threads)" default:"128"`
 	WithSizes      bool          `long:"with-size" description:"Output file sizes along with filenames"`
 	WithTimes      bool          `long:"with-times" description:"Output file with atime, mtime, ctime along with filenames"`
-	AtimeOlderThan time.Duration `long:"atime-older-than" description:"Filter files by access time older than this duration (e.g., 24h5m25s)" default:"0s"`
-	AtimeNewerThan time.Duration `long:"atime-newer-than" description:"Filter files by access time newer than this duration (e.g., 24h5m25s)" default:"0s"`
-	MtimeOlderThan time.Duration `long:"mtime-older-than" description:"Filter files by modification time older than this duration (e.g., 24h5m25s)" default:"0s"`
-	MtimeNewerThan time.Duration `long:"mtime-newer-than" description:"Filter files by modification time newer than this duration (e.g., 24h5m25s)" default:"0s"`
-	CtimeOlderThan time.Duration `long:"ctime-older-than" description:"Filter files by change time older than this duration (e.g., 24h5m25s)" default:"0s"`
-	CtimeNewerThan time.Duration `long:"ctime-newer-than" description:"Filter files by change time newer than this duration (e.g., 24h5m25s)" default:"0s"`
+	AtimeOlderThan time.Duration `long:"atime-older" description:"Filter files by access time older than this duration (e.g., 24h5m25s)" default:"0s"`
+	AtimeNewerThan time.Duration `long:"atime-newer" description:"Filter files by access time newer than this duration (e.g., 24h5m25s)" default:"0s"`
+	MtimeOlderThan time.Duration `long:"mtime-older" description:"Filter files by modification time older than this duration (e.g., 24h5m25s)" default:"0s"`
+	MtimeNewerThan time.Duration `long:"mtime-newer" description:"Filter files by modification time newer than this duration (e.g., 24h5m25s)" default:"0s"`
+	CtimeOlderThan time.Duration `long:"ctime-older" description:"Filter files by change time older than this duration (e.g., 24h5m25s)" default:"0s"`
+	CtimeNewerThan time.Duration `long:"ctime-newer" description:"Filter files by change time newer than this duration (e.g., 24h5m25s)" default:"0s"`
 	ResultThreads  int           `long:"result-jobs" description:"Number of jobs for processing results, like doing stats to get file sizes" default:"128"`
 	Delete         bool          `long:"delete" description:"Delete found files. Non empty directories will be ignored"`
 	DeleteAll      bool          `long:"delete-all" description:"Delete found files. Non empty directories will be removed with ALL their contents!!!"`

--- a/main.go
+++ b/main.go
@@ -316,9 +316,11 @@ func (e *Explorer) dumpResults() {
 			if e.delete {
 				err := os.Remove(result.name)
 				if err != nil {
-					log.Printf("Error deleting file %s: %v\n", result.name, err)
+					log.Printf("Delete failed: %s - Error: %v\n", result.name, err)
+					outputBuffer.WriteString(" [delete_failed]")
 				} else {
-					outputBuffer.WriteString(" deleted")
+					log.Printf("Delete success: %s\n", result.name)
+					outputBuffer.WriteString(" [delete_success]")
 				}
 			}
 
@@ -655,7 +657,7 @@ type Options struct {
 	CtimeOlderThan time.Duration `long:"ctime-older-than" description:"Filter files by change time older than this duration (e.g., 24h5m25s)" default:"0s"`
 	CtimeNewerThan time.Duration `long:"ctime-newer-than" description:"Filter files by change time newer than this duration (e.g., 24h5m25s)" default:"0s"`
 	ResultThreads  int           `long:"result-jobs" description:"Number of jobs for processing results, like doing stats to get file sizes" default:"128"`
-	Delete         bool          `short:"d" long:"delete" description:"Delete found files"`
+	Delete         bool          `long:"delete" description:"Delete found files"`
 
 	Exclude []string `short:"x" long:"exclude" description:"Patterns to exclude. Can be specified multiple times"`
 	Filter  []string `short:"f" long:"filter" description:"Patterns to filter by. Can be specified multiple times"`

--- a/main.go
+++ b/main.go
@@ -85,6 +85,7 @@ type Explorer struct {
 	includeDirs    bool
 	includeFiles   bool
 	includeLinks   bool
+	includeSocket  bool
 	includeAny     bool
 	started        bool
 	resultsThreads int
@@ -114,6 +115,8 @@ func (e *Explorer) SetIncludedTypes(types []string) {
 			e.includeDirs = true
 		case "link":
 			e.includeLinks = true
+		case "socket":
+			e.includeSocket = true
 		case "all":
 			e.includeAny = true
 		}
@@ -438,6 +441,10 @@ func (e *Explorer) readdir(dir string) {
 				if e.includeLinks || e.includeAny {
 					results = append(results, Result{fullpath, GetIno(dirent)})
 				}
+			case syscall.DT_SOCK:
+				if e.includeSocket || e.includeAny {
+					results = append(results, Result{fullpath, GetIno(dirent)})
+				}
 			default:
 				if e.includeAny {
 					results = append(results, Result{fullpath, GetIno(dirent)})
@@ -465,7 +472,7 @@ type Options struct {
 	Exclude []string `short:"x" long:"exclude" description:"Patterns to exclude. Can be specified multiple times"`
 	Filter  []string `short:"f" long:"filter" description:"Patterns to filter by. Can be specified multiple times"`
 
-	Type []string `short:"t" long:"type" default:"file" default:"dir" default:"link" description:"Search entries of specific type \nPossible values: file, dir, link, all. Can be specified multiple times"`
+	Type []string `short:"t" long:"type" default:"file" default:"dir" default:"link" default:"socket" description:"Search entries of specific type \nPossible values: file, dir, link, socket, all. Can be specified multiple times"`
 
 	Args struct {
 		Directories []string `positional-arg-name:"directories" description:"Directories to search, using current directory if missing"`
@@ -585,6 +592,8 @@ func entryType(direntType uint8) string {
 		return "file"
 	case syscall.DT_LNK:
 		return "link"
+	case syscall.DT_SOCK:
+		return "socket"
 	case syscall.DT_CHR:
 		return "char"
 	default:

--- a/readme.md
+++ b/readme.md
@@ -31,21 +31,31 @@ Usage:
   locar [OPTIONS] [directories...]
 
 Application Options:
-      --resilient    Do not stop on errors, instead print to stderr
-      --inodes       Output inodes along with filenames
-  -j, --jobs=        Number of jobs(threads) (default: 128)
-      --with-size    Output file sizes along with filenames
-      --result-jobs= Number of jobs for processing results, like doing stats to get file sizes (default: 128)
-  -x, --exclude=     Patterns to exclude. Can be specified multiple times
-  -f, --filter=      Patterns to filter by. Can be specified multiple times
-  -t, --type=        Search entries of specific type
-                     Possible values: file, dir, link, all. Can be specified multiple times (default: file, dir, link)
-      --timeout=     Timeout for readdir operations. Error will be reported, but os thread will be kept hanging (default: 5m)
-
+      --resilient          DEPRECATED and ignored, resilient is a default, use --stop-on-error if it is undesired behaviour
+      --stop-on-error      Aborts scan on any error
+      --inodes             Output inodes (decimal) along with filenames
+      --inodes-hex         Output inodes (hexadecimal) along with filenames
+      --raw                Output filenames as escaped strings
+  -j, --jobs=              Number of jobs(threads) (default: 128)
+      --with-size          Output file sizes along with filenames
+      --with-times         Output file with atime, mtime, ctime along with filenames
+      --atime-older=       Filter files by access time older than this duration (e.g., 24h5m25s) (default: 0s)
+      --atime-newer=       Filter files by access time newer than this duration (e.g., 24h5m25s) (default: 0s)
+      --mtime-older=       Filter files by modification time older than this duration (e.g., 24h5m25s) (default: 0s)
+      --mtime-newer=       Filter files by modification time newer than this duration (e.g., 24h5m25s) (default: 0s)
+      --ctime-older=       Filter files by change time older than this duration (e.g., 24h5m25s) (default: 0s)
+      --ctime-newer=       Filter files by change time newer than this duration (e.g., 24h5m25s) (default: 0s)
+      --result-jobs=       Number of jobs for processing results, like doing stats to get file sizes (default: 128)
+  -x, --exclude=           Patterns to exclude. Can be specified multiple times
+  -f, --filter=            Patterns to filter by. Can be specified multiple times
+  -t, --type=              Search entries of specific type. Possible values: file, dir, link, socket, all. Can be specified multiple times (default: file, dir, link, socket)
+      --timeout=           Timeout for readdir operations. Error will be reported, but os thread will be kept hanging (default: 5m)
+      --delete             Delete found files. Non-empty directories will be ignored.
+      --delete-all         Delete found files. Non-empty directories will be removed with ALL their contents!!!
 
 Help Options:
-  -h, --help         Show this help message
+  -h, --help               Show this help message
 
 Arguments:
-  directories:       Directories to search, using current directory if missing
+  directories:             Directories to search, using current directory if missing
 ```

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,28 @@ user 1m7.076s
 sys 0m39.272s
 ```
 
+
+Find Files Newer than 72h Using `find`
+```
+>> time find /scratch/img -type f -ctime -3 -mtime -3 -atime -3 | wc -l
+495702
+
+real	2m56.041s
+user	0m1.390s
+sys	0m8.526s
+```
+
+Find Files Newer than 72h Using `locar`
+
+```
+>> time ./locar -t file --atime-newer=72h --mtime-newer=72h --ctime-newer=72h /scratch/img | wc -l
+495702
+
+real	0m14.686s
+user	0m2.349s
+sys	0m4.508s
+```
+
 I.e ~almost X35 speedup
 
 
@@ -31,31 +53,33 @@ Usage:
   locar [OPTIONS] [directories...]
 
 Application Options:
-      --resilient          DEPRECATED and ignored, resilient is a default, use --stop-on-error if it is undesired behaviour
-      --stop-on-error      Aborts scan on any error
-      --inodes             Output inodes (decimal) along with filenames
-      --inodes-hex         Output inodes (hexadecimal) along with filenames
-      --raw                Output filenames as escaped strings
-  -j, --jobs=              Number of jobs(threads) (default: 128)
-      --with-size          Output file sizes along with filenames
-      --with-times         Output file with atime, mtime, ctime along with filenames
-      --atime-older=       Filter files by access time older than this duration (e.g., 24h5m25s) (default: 0s)
-      --atime-newer=       Filter files by access time newer than this duration (e.g., 24h5m25s) (default: 0s)
-      --mtime-older=       Filter files by modification time older than this duration (e.g., 24h5m25s) (default: 0s)
-      --mtime-newer=       Filter files by modification time newer than this duration (e.g., 24h5m25s) (default: 0s)
-      --ctime-older=       Filter files by change time older than this duration (e.g., 24h5m25s) (default: 0s)
-      --ctime-newer=       Filter files by change time newer than this duration (e.g., 24h5m25s) (default: 0s)
-      --result-jobs=       Number of jobs for processing results, like doing stats to get file sizes (default: 128)
-  -x, --exclude=           Patterns to exclude. Can be specified multiple times
-  -f, --filter=            Patterns to filter by. Can be specified multiple times
-  -t, --type=              Search entries of specific type. Possible values: file, dir, link, socket, all. Can be specified multiple times (default: file, dir, link, socket)
-      --timeout=           Timeout for readdir operations. Error will be reported, but os thread will be kept hanging (default: 5m)
-      --delete             Delete found files. Non-empty directories will be ignored.
-      --delete-all         Delete found files. Non-empty directories will be removed with ALL their contents!!!
+      --resilient      DEPRECATED and ignored, resilient is a default, use --stop-on-error if it is undesired behaviour
+      --stop-on-error  Aborts scan on any error
+      --inodes         Output inodes (decimal) along with filenames
+      --inodes-hex     Output inodes (hexadecimal) along with filenames
+      --raw            Output filenames as escaped strings
+  -j, --jobs=          Number of jobs(threads) (default: 128)
+      --with-size      Output file sizes along with filenames
+      --with-times     Output file with atime, mtime, ctime along with filenames
+      --atime-older=   Filter files by access time older than this duration (e.g., 24h5m25s) (default: 0s)
+      --atime-newer=   Filter files by access time newer than this duration (e.g., 24h5m25s) (default: 0s)
+      --mtime-older=   Filter files by modification time older than this duration (e.g., 24h5m25s) (default: 0s)
+      --mtime-newer=   Filter files by modification time newer than this duration (e.g., 24h5m25s) (default: 0s)
+      --ctime-older=   Filter files by change time older than this duration (e.g., 24h5m25s) (default: 0s)
+      --ctime-newer=   Filter files by change time newer than this duration (e.g., 24h5m25s) (default: 0s)
+      --result-jobs=   Number of jobs for processing results, like doing stats to get file sizes (default: 128)
+      --delete         Delete found files. Non empty directories will be ignored
+      --delete-all     Delete found files. Non empty directories will be removed with ALL their contents!!!
+  -v, --version        Show version
+  -x, --exclude=       Patterns to exclude. Can be specified multiple times
+  -f, --filter=        Patterns to filter by. Can be specified multiple times
+  -t, --type=          Search entries of specific type
+                       Possible values: file, dir, link, socket, all. Can be specified multiple times (default: file, dir, link, socket)
+      --timeout=       Timeout for readdir operations. Error will be reported, but os thread will be kept hanging (default: 5m)
 
 Help Options:
-  -h, --help               Show this help message
+  -h, --help           Show this help message
 
 Arguments:
-  directories:             Directories to search, using current directory if missing
+  directories:         Directories to search, using current directory if missing
 ```


### PR DESCRIPTION
#### **Dear Weka Team,**

I have added the following functionalities to `locar`:

-   **Filtering files by time attributes** (`mtime`, `atime`, `ctime`).
-   **Support for searching sockets** in file systems.
-   **Ability to remove files** (non-empty directories are ignored by default, but an option is added to remove directories along with their files).

Below, I provide benchmarks and explanations.

* * * * *

### **Filtering Files by Time Attributes**

I have added support to search for files based on their modification (`mtime`), access (`atime`), and change (`ctime`) times.

#### **Benchmark Results:**

##### **Baseline - Listing All Files (1098229 Files in Folder)**
```
>> time locar /scratch/img | wc -l
1098229

real	0m13.470s
user	0m1.994s
sys	0m3.061s
```

##### **Find Files Newer than 72h Using `find`**
```
>> time find /scratch/img -type f -ctime -3 -mtime -3 -atime -3 | wc -l
495702

real	2m56.041s
user	0m1.390s
sys	0m8.526s
```

##### **Find Files Newer than 72h Using `locar`**

```
>> time ./locar -t file --atime-newer=72h --mtime-newer=72h --ctime-newer=72h /scratch/img | wc -l
495702

real	0m14.686s
user	0m2.349s
sys	0m4.508s
```

➡️ **Result**: `locar` is significantly faster than `find`, completing the same operation in **14.7s vs. 2m56s**.

* * * * *

### **Deleting Files with Special Characters in Names**

The standard `xargs` command fails when handling filenames containing single quotes (`'`) or other special characters.

#### **Example:**

Consider a directory with the following files:
```
>> ls test_directory
test_file1  test_file2  "testfile'test.xlsx"
```

##### **Delete files with  quotes (`'`)  `locar| xargs rm`**
```
>> locar --type file test_directory | xargs -P128 -n128 rm -f 2>&1
xargs: unmatched single quote; by default quotes are special to xargs unless you use the -0 option
>> ls test_directory
test_file1  test_file2  "testfile'test.xlsx"
```
`xargs` fails to remove the files `"testfile'test.xlsx"` because of the unmatched single quote.

##### **Delete files with  quotes (`'`)  `locar`**

```./locar --type file --delete test_directory
2025/01/29 23:32:49 Delete success: test_directory/test_file1
2025/01/29 23:32:49 Delete success: test_directory/test_file2
2025/01/29 23:32:49 Delete success:  test_directory/testfile'test.xlsx 
test_directory/testfile'test.xlsx [delete_success]
test_directory/test_file1 [delete_success]
test_directory/test_file2 [delete_success]
```

➡️ **Solution:** This update ensures proper handling of filenames with special characters.

* * * * *

### **Searching for Sockets**

On large HPC platforms, you may encounter **orphaned (dead) processes** that do not clean up their sockets. Previously, `locar` ignored these socket files.\
With this update, `locar` can now detect and list orphaned sockets, helping system administrators identify and clean up unnecessary resources.

* * * * *

### **Summary of Enhancements:**

✔ **Performance improvement** over `find` for filtering by time attributes.\
✔ **Better file deletion handling**, especially for filenames with special characters.\
✔ **Ability to detect orphaned sockets**, which were previously ignored.

Looking forward to your feedback! 🚀